### PR TITLE
Question about Authetivcation

### DIFF
--- a/src/main/java/com/example/demo/SecurityConfig.java
+++ b/src/main/java/com/example/demo/SecurityConfig.java
@@ -1,5 +1,10 @@
 package com.example.demo;
 
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,4 +116,34 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.passwordEncoder(passwordEncoder()); //ログイン時にパスワード復号
 
 	}
+
+    public static void authWithHttpServletRequestLogin(HttpServletRequest request, String username, String password, HttpServletResponse response) throws IOException {
+
+    	if(request.getUserPrincipal() != null) {
+    		authWithHttpServletRequestLogout(request, response);
+    		System.out.println("認証済みの状態だったからログアウトしたよ");
+    	}
+
+        try {
+            request.login(username, password);
+            System.out.println(username + "＆");
+			System.out.println(password + "＆");
+            String url = "/mypage";
+    		response.sendRedirect(url);
+        } catch (ServletException e) {
+        	String url = "/login";
+    		response.sendRedirect(url);
+        }
+
+
+    }
+    public static void authWithHttpServletRequestLogout(HttpServletRequest request,HttpServletResponse response) throws IOException {
+        try {
+            request.logout();
+            System.out.println("ログアウト実行");
+        } catch (ServletException e) {
+        	String url = "/login";
+    		response.sendRedirect(url);
+        }
+    }
 }

--- a/src/main/java/com/example/demo/login/controller/MyPageController.java
+++ b/src/main/java/com/example/demo/login/controller/MyPageController.java
@@ -1,8 +1,10 @@
 package com.example.demo.login.controller;
 
+import java.io.IOException;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import com.example.demo.SecurityConfig;
 import com.example.demo.login.domain.model.FavOmiyage;
 import com.example.demo.login.domain.model.GroupOrder;
 import com.example.demo.login.domain.model.SignupForm;
@@ -101,16 +104,17 @@ public class MyPageController {
 
 	//ユーザー登録情報更新実行用メソッド
 	@PostMapping("/updateUserInfo") //「GroupOrder」で設定した順序でバリデーションを実行
-	public String postUserUpdate(@ModelAttribute @Validated(GroupOrder.class)SignupForm form, BindingResult bindingResult, Model model, HttpServletRequest httpServletRequest) {
+	public String postUserUpdate(@ModelAttribute @Validated(GroupOrder.class)SignupForm form, BindingResult bindingResult, Model model, HttpServletRequest request,
+			HttpServletResponse response) {
 
 		//バインディングでエラー発生(バリデーションエラー含む)した場合、登録情報更新ページへ遷移
 		if (bindingResult.hasErrors()) {
-			return PostUserUpdatePage(form, model, httpServletRequest);
+			return PostUserUpdatePage(form, model, request);
 
 		}
 
 		//更新対象のユーザーを検索するために認証済みのユーザーIDを取得
-		String userId_LoggedIn = httpServletRequest.getRemoteUser();
+		String userId_LoggedIn = request.getRemoteUser();
 
 		//ユーザーID取得確認用
 		System.out.println("ログインしているのは"+ userId_LoggedIn);
@@ -135,8 +139,18 @@ public class MyPageController {
 			System.out.println("更新失敗");
 		}
 
-		//更新後、再認証をするためにログアウトさせる
-		return "logout/logout";
+		try {
+			String username = String.valueOf(form.getUserId());
+			String password = String.valueOf(form.getPassword());
+			System.out.println(username);
+			System.out.println(password);
+			SecurityConfig.authWithHttpServletRequestLogin(request, username, password, response);
+			 System.out.println("ログイン実行");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		return null;
 	}
 
 	//お気に入り画面表示用

--- a/src/main/java/com/example/demo/login/controller/SignupController.java
+++ b/src/main/java/com/example/demo/login/controller/SignupController.java
@@ -1,5 +1,10 @@
 package com.example.demo.login.controller;
 
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
@@ -11,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import com.example.demo.SecurityConfig;
 import com.example.demo.login.domain.model.GroupOrder;
 import com.example.demo.login.domain.model.SignupForm;
 import com.example.demo.login.domain.model.User;
@@ -32,7 +38,8 @@ public class SignupController {
 
 	//ユーザー新規登録実行用メソッド
 	@PostMapping("/signupUser") //「GroupOrder」で設定した順序でバリデーションを実行
-	public String postSignUp(@ModelAttribute @Validated(GroupOrder.class) SignupForm form, BindingResult bindingResult, Model model) {
+	public String postSignUp(@ModelAttribute @Validated(GroupOrder.class) SignupForm form, BindingResult bindingResult, Model model, HttpServletRequest request,
+			HttpServletResponse response) {
 
 		//バインディングでエラー発生(バリデーションエラー含む)した場合、ユーザー登録画面へ遷移
 		if (bindingResult.hasErrors()) {
@@ -61,8 +68,15 @@ public class SignupController {
 			System.out.println("insert失敗");
 		}
 
-		//ログイン画面へ遷移
-		return "redirect:/login";
+		try {
+			String username = String.valueOf(form.getUserId());
+			String password = String.valueOf(form.getPassword());
+			SecurityConfig.authWithHttpServletRequestLogin(request, username, password, response);
+		} catch (IOException e) {
+			// TODO 自動生成された catch ブロック
+			e.printStackTrace();
+		}
+		return null;
 
 	}
 

--- a/src/main/resources/templates/layout/template.html
+++ b/src/main/resources/templates/layout/template.html
@@ -30,7 +30,7 @@
 				    <li class="nav-item">
 						<a class="nav-link" href="/home">Home</a>
 					</li>
-					<li class="nav-item">
+					<li class="nav-item" sec:authorize="isAnonymous()">
 						<a class="nav-link" href="/login">Login</a> <!--「LoginController」の「/login」へ処理が呼ばれる-->
 					</li>
 					<li class="nav-item"> <!--「Snitch」説明ページへ遷移-->


### PR DESCRIPTION
ユーザー登録情報更新後、認証済み状態での新規登録を行った場合、自動ログインが行われず、マイページへ遷移しません。


#7「新規登録時に成功したのかどうかわからない」の対応で、登録作業後自動ログインされるよう改修しました。

新規登録→自動ログインという通常のフローは問題なく実現できました。

ただ、下記のパターンだとマイページに移行せず、当初のように新規登録後マイページに遷移せず、ログインページに移行してしまいます。

例
ユーザAでログイン→ログアウトせずにそのままログインページから新規登録でユーザーBを新規登録

また、この#7に関連してユーザー登録情報変更後、これまでログアウトを実行していたものを、
登録情報更新後マイページに遷移させるよう修正を試みたのですが、ログアウトは実行されるものの、マイページには遷移せず
ログインページに遷移します。

「SecurityConfig.java」では下記をコメントアウトしたものの、ログインページへ遷移してしまいます。
・"/.failureUrl("/login") //ログイン失敗時は再度ログインページへ遷移"
・"logoutSuccessUrl("/login"); //ログアウト成功時ログイン画面へ遷移"
・String url = "/login";


また、コンソールでは一切エラーは表示されておらず、コンソール上問題なく処理されているような印象を受けます。

ちなみに登録情報更新も上記のような認証済み状態での新規登録も、
遷移先のログインページでIDとPASSを入力すれば正常にログインはできます。
また、自動ログインのメソッドで利用する変数(username、password)が正しく取得できていないという可能性を疑い、
ログイン実行と合わせて変数のコンソール表示（system.out.println）も試しましたが、こちらも問題なく取得できていることがわかりました。











