### PR TITLE
Throw data exception

### DIFF
--- a/src/main/java/com/example/demo/login/controller/AboutSnitchController.java
+++ b/src/main/java/com/example/demo/login/controller/AboutSnitchController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class AboutSnitchController {
 
 	@GetMapping("/aboutsnitch")
-	public String showAboutPage() {
+	public String show() {
 
 		return "about/aboutSnitch";
 	}

--- a/src/main/java/com/example/demo/login/controller/AboutSnitchController.java
+++ b/src/main/java/com/example/demo/login/controller/AboutSnitchController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class AboutSnitchController {
 
 	@GetMapping("/aboutsnitch")
-	public String getSnitch() {
+	public String showAboutPage() {
 
 		return "about/aboutSnitch";
 	}

--- a/src/main/java/com/example/demo/login/controller/FavGiftController.java
+++ b/src/main/java/com/example/demo/login/controller/FavGiftController.java
@@ -20,40 +20,40 @@ public class FavGiftController {
 	@Autowired
 	FavGiftService favGiftService;
 
-	@PostMapping("/addGiftToFav")
-	public void postAddGiftToFav(Model model, @RequestParam("giftId") int giftId, HttpServletRequest httpServletRequest, HttpServletResponse response) throws IOException {
+	@PostMapping("/createFavGift")
+	public void create(Model model, @RequestParam("giftId") int giftId, HttpServletRequest httpServletRequest, HttpServletResponse response) throws IOException {
 
 		String userName = httpServletRequest.getRemoteUser();
 
-		boolean resultAddGiftToFav = favGiftService.addGiftToFav(userName, giftId);
+		boolean result = favGiftService.create(userName, giftId);
 
-		if(resultAddGiftToFav == true) {
+		if(result == true) {
 			System.out.println("お気に入り登録成功");
 		} else {
 			System.out.println("お気に入り登録失敗");
 		}
 
-		String giftDeatllUrl = "/giftDetail/" + giftId;
+		String url = "/giftDetail/" + giftId;
 
-		response.sendRedirect(giftDeatllUrl);
+		response.sendRedirect(url);
 	}
 
 	@PostMapping("/deleteGiftFromFav")
-	public void postdeleteGiftFromFav(Model model, @RequestParam("giftId") int giftId, HttpServletRequest request, HttpServletResponse response) throws IOException {
+	public void delete(Model model, @RequestParam("giftId") int giftId, HttpServletRequest request, HttpServletResponse response) throws IOException {
 
 		String userName = request.getRemoteUser();
 
-		boolean resultDeleteGiftFromFav = favGiftService.deleteGiftFromFav(userName, giftId);
+		boolean result = favGiftService.delete(userName, giftId);
 
-		if(resultDeleteGiftFromFav == true) {
+		if(result == true) {
 			System.out.println("お気に入り登録解除完了");
 		} else {
 			System.out.println("お気に入り登録解除成功");
 		}
 
-		String giftDeatllUrl = "/giftDetail/" + giftId;
+		String url = "/giftDetail/" + giftId;
 
-		response.sendRedirect(giftDeatllUrl);
+		response.sendRedirect(url);
 	}
 }
 

--- a/src/main/java/com/example/demo/login/controller/FavGiftController.java
+++ b/src/main/java/com/example/demo/login/controller/FavGiftController.java
@@ -20,7 +20,7 @@ public class FavGiftController {
 	@Autowired
 	FavGiftService favGiftService;
 
-	@PostMapping("/createFavGift")
+	@PostMapping("/favGift")
 	public void create(Model model, @RequestParam("giftId") int giftId, HttpServletRequest httpServletRequest, HttpServletResponse response) throws IOException {
 
 		String userName = httpServletRequest.getRemoteUser();
@@ -38,7 +38,7 @@ public class FavGiftController {
 		response.sendRedirect(url);
 	}
 
-	@PostMapping("/deleteGiftFromFav")
+	@PostMapping("/notFavGift")
 	public void delete(Model model, @RequestParam("giftId") int giftId, HttpServletRequest request, HttpServletResponse response) throws IOException {
 
 		String userName = request.getRemoteUser();

--- a/src/main/java/com/example/demo/login/controller/FavGiftController.java
+++ b/src/main/java/com/example/demo/login/controller/FavGiftController.java
@@ -20,40 +20,40 @@ public class FavGiftController {
 	@Autowired
 	FavGiftService favGiftService;
 
-	@PostMapping("/addGift")
-	public void getFavGiftAdd(Model model, @RequestParam("giftId") int giftId, HttpServletRequest httpServletRequest, HttpServletResponse response) throws IOException {
+	@PostMapping("/addGiftToFav")
+	public void postAddGiftToFav(Model model, @RequestParam("giftId") int giftId, HttpServletRequest httpServletRequest, HttpServletResponse response) throws IOException {
 
 		String userName = httpServletRequest.getRemoteUser();
 
-		boolean result = favGiftService.insert(userName, giftId);
+		boolean resultAddGiftToFav = favGiftService.addGiftToFav(userName, giftId);
 
-		if(result == true) {
+		if(resultAddGiftToFav == true) {
 			System.out.println("お気に入り登録成功");
 		} else {
 			System.out.println("お気に入り登録失敗");
 		}
 
-		String url = "/giftDetail/" + giftId;
+		String giftDeatllUrl = "/giftDetail/" + giftId;
 
-		response.sendRedirect(url);
+		response.sendRedirect(giftDeatllUrl);
 	}
 
-	@PostMapping("/deleteFavGift")
-	public void getFavGiftDelite(Model model, @RequestParam("giftId") int giftId, HttpServletRequest request, HttpServletResponse response) throws IOException {
+	@PostMapping("/deleteGiftFromFav")
+	public void postdeleteGiftFromFav(Model model, @RequestParam("giftId") int giftId, HttpServletRequest request, HttpServletResponse response) throws IOException {
 
 		String userName = request.getRemoteUser();
 
-		boolean result = favGiftService.delete(userName, giftId);
+		boolean resultDeleteGiftFromFav = favGiftService.deleteGiftFromFav(userName, giftId);
 
-		if(result == true) {
+		if(resultDeleteGiftFromFav == true) {
 			System.out.println("お気に入り登録解除完了");
 		} else {
 			System.out.println("お気に入り登録解除成功");
 		}
 
-		String url = "/giftDetail/" + giftId;
+		String giftDeatllUrl = "/giftDetail/" + giftId;
 
-		response.sendRedirect(url);
+		response.sendRedirect(giftDeatllUrl);
 	}
 }
 

--- a/src/main/java/com/example/demo/login/controller/GiftDetailController.java
+++ b/src/main/java/com/example/demo/login/controller/GiftDetailController.java
@@ -42,9 +42,9 @@ public class GiftDetailController {
 
 			String userName = httpServletRequest.getRemoteUser();
 
-			int favIdResult = favGiftService.searchFavId(userName, giftId);
+			int favId = favGiftService.searchFavId(userName, giftId);
 
-			model.addAttribute("favIdResultModel", favIdResult);
+			model.addAttribute("favId", favId);
 
 		return "giftDetail/giftDetail";
 	}

--- a/src/main/java/com/example/demo/login/controller/MyPageController.java
+++ b/src/main/java/com/example/demo/login/controller/MyPageController.java
@@ -130,13 +130,13 @@ public class MyPageController {
 
 		String userName = httpServletRequest.getRemoteUser();
 
-		List<FavGift> allfavGifts = favGiftService.selectAll(userName);
+		List<FavGift> allFavGifts = favGiftService.selectAll(userName);
 
-		model.addAttribute("allfavGifts", allfavGifts);
+		model.addAttribute("allFavGifts", allFavGifts);
 
-		int number = favGiftService.count(userName);
+		int count = favGiftService.count(userName);
 
-		model.addAttribute("number", number);
+		model.addAttribute("count", count);
 
 		return "mypage/favorite/favorite";
 	}

--- a/src/main/java/com/example/demo/login/controller/MyPageController.java
+++ b/src/main/java/com/example/demo/login/controller/MyPageController.java
@@ -130,15 +130,13 @@ public class MyPageController {
 
 		String userName = httpServletRequest.getRemoteUser();
 
-		System.out.println("ログインしているのは"+userName);
+		List<FavGift> allfavGifts = favGiftService.selectAll(userName);
 
-		List<FavGift> favGiftList = favGiftService.selectMany(userName);
+		model.addAttribute("allfavGifts", allfavGifts);
 
-		model.addAttribute("favGiftList", favGiftList);
+		int number = favGiftService.count(userName);
 
-		int count = favGiftService.count(userName);
-
-		model.addAttribute("favGiftListCount", count);
+		model.addAttribute("number", number);
 
 		return "mypage/favorite/favorite";
 	}

--- a/src/main/java/com/example/demo/login/domain/repository/FavGiftDao.java
+++ b/src/main/java/com/example/demo/login/domain/repository/FavGiftDao.java
@@ -13,9 +13,9 @@ public interface FavGiftDao  {
 
 	public int count(String userName) throws DataAccessException;
 
-	public int insert(String userName, int giftId) throws DataAccessException;
+	public int addGiftToFav(String userName, int giftId) throws DataAccessException;
 
 	public int searchFavId(String userName, int giftId) throws DataAccessException;
 
-	public int delete(String userName, int giftId) throws DataAccessException;
+	public int deleteGiftFromFav(String userName, int giftId) throws DataAccessException;
 }

--- a/src/main/java/com/example/demo/login/domain/repository/FavGiftDao.java
+++ b/src/main/java/com/example/demo/login/domain/repository/FavGiftDao.java
@@ -9,7 +9,7 @@ import com.example.demo.login.domain.model.FavGift;
 
 public interface FavGiftDao  {
 
-	public List<FavGift> selectMany(String userName) throws DataAccessException;
+	public List<FavGift> selectAll(String userName) throws DataAccessException;
 
 	public int count(String userName) throws DataAccessException;
 

--- a/src/main/java/com/example/demo/login/domain/repository/FavGiftDao.java
+++ b/src/main/java/com/example/demo/login/domain/repository/FavGiftDao.java
@@ -13,9 +13,9 @@ public interface FavGiftDao  {
 
 	public int count(String userName) throws DataAccessException;
 
-	public int addGiftToFav(String userName, int giftId) throws DataAccessException;
+	public int create(String userName, int giftId) throws DataAccessException;
 
 	public int searchFavId(String userName, int giftId) throws DataAccessException;
 
-	public int deleteGiftFromFav(String userName, int giftId) throws DataAccessException;
+	public int delete(String userName, int giftId) throws DataAccessException;
 }

--- a/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
+++ b/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
@@ -25,7 +25,7 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 
 			List<Map<String, Object>> favGifts = jdbc.queryForList("SELECT * FROM favGift INNER JOIN gift ON favGift.giftId = gift.giftId INNER JOIN guest ON gift.guestId = guest.guestId WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
 
-			List<FavGift> allfavGifts = new ArrayList<>();
+			List<FavGift> allFavGifts = new ArrayList<>();
 
 			for(Map<String, Object> map: favGifts) {
 
@@ -43,9 +43,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 				favGift.setAddress((String)map.get("address"));
 				favGift.setPhone((String)map.get("phone"));
 
-				allfavGifts.add(favGift);
+				allFavGifts.add(favGift);
 			}
-			return allfavGifts;
+			return allFavGifts;
 		}
 
 	@Override
@@ -75,9 +75,7 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 
 		List<Map<String, Object>> giftIds = jdbc.queryForList("SELECT giftId FROM favGift WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
 
-		int number = giftIds.size();
-
-		return number;
+		return giftIds.size();
 	}
 
 	@Override

--- a/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
+++ b/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
@@ -19,15 +19,15 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	JdbcTemplate jdbc;
 
 	@Override
-	public List<FavGift> selectMany(String userName) throws DataAccessException {
+	public List<FavGift> selectAll(String userName) throws DataAccessException {
 
 		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-			List<Map<String, Object>>  getList = jdbc.queryForList("SELECT * FROM favGift INNER JOIN gift ON favGift.giftId = gift.giftId INNER JOIN guest ON gift.guestId = guest.guestId WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
+			List<Map<String, Object>> favGifts = jdbc.queryForList("SELECT * FROM favGift INNER JOIN gift ON favGift.giftId = gift.giftId INNER JOIN guest ON gift.guestId = guest.guestId WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
 
-			List<FavGift> favGiftList = new ArrayList<>();
+			List<FavGift> allfavGifts = new ArrayList<>();
 
-			for(Map<String, Object> map: getList) {
+			for(Map<String, Object> map: favGifts) {
 
 				FavGift favGift = new FavGift();
 
@@ -43,9 +43,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 				favGift.setAddress((String)map.get("address"));
 				favGift.setPhone((String)map.get("phone"));
 
-				favGiftList.add(favGift);
+				allfavGifts.add(favGift);
 			}
-			return favGiftList;
+			return allfavGifts;
 		}
 
 	@Override
@@ -54,15 +54,15 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 		try {
 			Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-			Map<String, Object> favIdFind = jdbc.queryForMap("SELECT favId FROM favGift WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"), giftId);
+			Map<String, Object> favId = jdbc.queryForMap("SELECT favId FROM favGift WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"), giftId);
 
-			int favId2 =  (int) favIdFind.get("favId");
+			int castedFavId =  (int) favId.get("favId");
 
-			return favId2;
+			return castedFavId;
 
 		} catch(DataAccessException e) {
-			int favId2 = 0;
-			return favId2;
+			int favId = 0;
+			return favId;
 		}
 
 
@@ -73,11 +73,11 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 
 		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		List<Map<String, Object>>  getList = jdbc.queryForList("SELECT giftId FROM favGift WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
+		List<Map<String, Object>> giftIds = jdbc.queryForList("SELECT giftId FROM favGift WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
 
-		int favCount = getList.size();
+		int number = giftIds.size();
 
-		return favCount;
+		return number;
 	}
 
 	@Override
@@ -85,9 +85,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 
 		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		int favGiftRowNumber = jdbc.update("INSERT INTO favGift(userId, giftId) VALUES(?, ?)", userId.get("userId"), giftId);
+		int suceededRowNumber = jdbc.update("INSERT INTO favGift(userId, giftId) VALUES(?, ?)", userId.get("userId"), giftId);
 
-		return favGiftRowNumber;
+		return suceededRowNumber;
 	}
 
 	@Override
@@ -95,9 +95,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 
 		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		int favGiftRowNumber = jdbc.update("UPDATE favGift SET unavailableFlag = '1' WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"), giftId);
+		int suceededRowNumber = jdbc.update("UPDATE favGift SET unavailableFlag = '1' WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"), giftId);
 
-		return favGiftRowNumber;
+		return suceededRowNumber;
 	}
 
 

--- a/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
+++ b/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
@@ -49,7 +49,7 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 		}
 
 	@Override
-	public int searchFavId(String userName, int giftId) throws DataAccessException {
+	public int searchFavId(String userName, int giftId) {
 
 		try {
 			Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
@@ -62,6 +62,7 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 
 		} catch(DataAccessException e) {
 			int favId = 0;
+
 			return favId;
 		}
 

--- a/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
+++ b/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
@@ -21,9 +21,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	@Override
 	public List<FavGift> selectMany(String userName) throws DataAccessException {
 
-		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-			List<Map<String, Object>>  getList = jdbc.queryForList("SELECT * FROM favGift INNER JOIN gift ON favGift.giftId = gift.giftId INNER JOIN guest ON gift.guestId = guest.guestId WHERE userId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"));
+			List<Map<String, Object>>  getList = jdbc.queryForList("SELECT * FROM favGift INNER JOIN gift ON favGift.giftId = gift.giftId INNER JOIN guest ON gift.guestId = guest.guestId WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
 
 			List<FavGift> favGiftList = new ArrayList<>();
 
@@ -52,9 +52,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	public int searchFavId(String userName, int giftId) throws DataAccessException {
 
 		try {
-			Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+			Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-			Map<String, Object> favIdFind = jdbc.queryForMap("SELECT favId FROM favGift WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"), giftId);
+			Map<String, Object> favIdFind = jdbc.queryForMap("SELECT favId FROM favGift WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"), giftId);
 
 			int favId2 =  (int) favIdFind.get("favId");
 
@@ -71,9 +71,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	@Override
 	public int count(String userName) throws DataAccessException {
 
-		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		List<Map<String, Object>>  getList = jdbc.queryForList("SELECT giftId FROM favGift WHERE userId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"));
+		List<Map<String, Object>>  getList = jdbc.queryForList("SELECT giftId FROM favGift WHERE userId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"));
 
 		int favCount = getList.size();
 
@@ -81,23 +81,21 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	}
 
 	@Override
-	public int addGiftToFav(String userName, int giftId) throws DataAccessException {
+	public int create(String userName, int giftId) throws DataAccessException {
 
-		System.out.println(userName+"この情報で検索");
+		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
-
-		int favGiftRowNumber = jdbc.update("INSERT INTO favGift(userId, giftId) VALUES(?, ?)", mapForUserId.get("userId"), giftId);
+		int favGiftRowNumber = jdbc.update("INSERT INTO favGift(userId, giftId) VALUES(?, ?)", userId.get("userId"), giftId);
 
 		return favGiftRowNumber;
 	}
 
 	@Override
-	public int deleteGiftFromFav(String userName, int giftId)throws DataAccessException{
+	public int delete(String userName, int giftId)throws DataAccessException{
 
-		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+		Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		int favGiftRowNumber = jdbc.update("UPDATE favGift SET unavailableFlag = '1' WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"), giftId);
+		int favGiftRowNumber = jdbc.update("UPDATE favGift SET unavailableFlag = '1' WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"), giftId);
 
 		return favGiftRowNumber;
 	}

--- a/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
+++ b/src/main/java/com/example/demo/login/domain/repository/jdbc/FavGiftDaoJdbcImpl.java
@@ -21,9 +21,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	@Override
 	public List<FavGift> selectMany(String userName) throws DataAccessException {
 
-		Map<String, Object> mapForID = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-			List<Map<String, Object>>  getList = jdbc.queryForList("SELECT * FROM favGift INNER JOIN gift ON favGift.giftId = gift.giftId INNER JOIN guest ON gift.guestId = guest.guestId WHERE userId = ? AND favGift.unavailableFlag IS NULL", mapForID.get("userId"));
+			List<Map<String, Object>>  getList = jdbc.queryForList("SELECT * FROM favGift INNER JOIN gift ON favGift.giftId = gift.giftId INNER JOIN guest ON gift.guestId = guest.guestId WHERE userId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"));
 
 			List<FavGift> favGiftList = new ArrayList<>();
 
@@ -52,9 +52,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	public int searchFavId(String userName, int giftId) throws DataAccessException {
 
 		try {
-			Map<String, Object> mapForID = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+			Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-			Map<String, Object> favIdFind = jdbc.queryForMap("SELECT favId FROM favGift WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", mapForID.get("userId"), giftId);
+			Map<String, Object> favIdFind = jdbc.queryForMap("SELECT favId FROM favGift WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"), giftId);
 
 			int favId2 =  (int) favIdFind.get("favId");
 
@@ -71,9 +71,9 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	@Override
 	public int count(String userName) throws DataAccessException {
 
-		Map<String, Object> mapForID = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		List<Map<String, Object>>  getList = jdbc.queryForList("SELECT giftId FROM favGift WHERE userId = ? AND favGift.unavailableFlag IS NULL", mapForID.get("userId"));
+		List<Map<String, Object>>  getList = jdbc.queryForList("SELECT giftId FROM favGift WHERE userId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"));
 
 		int favCount = getList.size();
 
@@ -81,25 +81,25 @@ public class FavGiftDaoJdbcImpl implements FavGiftDao {
 	}
 
 	@Override
-	public int insert(String userName, int giftId) throws DataAccessException {
+	public int addGiftToFav(String userName, int giftId) throws DataAccessException {
 
 		System.out.println(userName+"この情報で検索");
 
-		Map<String, Object> mapForID = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		int rowNumber = jdbc.update("INSERT INTO favGift(userId, giftId) VALUES(?, ?)", mapForID.get("userId"), giftId);
+		int favGiftRowNumber = jdbc.update("INSERT INTO favGift(userId, giftId) VALUES(?, ?)", mapForUserId.get("userId"), giftId);
 
-		return rowNumber;
+		return favGiftRowNumber;
 	}
 
 	@Override
-	public int delete(String userName, int giftId)throws DataAccessException{
+	public int deleteGiftFromFav(String userName, int giftId)throws DataAccessException{
 
-		Map<String, Object> mapForID = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
+		Map<String, Object> mapForUserId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);
 
-		int rowNumber = jdbc.update("UPDATE favGift SET unavailableFlag = '1' WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", mapForID.get("userId"), giftId);
+		int favGiftRowNumber = jdbc.update("UPDATE favGift SET unavailableFlag = '1' WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", mapForUserId.get("userId"), giftId);
 
-		return rowNumber;
+		return favGiftRowNumber;
 	}
 
 

--- a/src/main/java/com/example/demo/login/domain/repository/jdbc/UserDaoJdbcImpl.java
+++ b/src/main/java/com/example/demo/login/domain/repository/jdbc/UserDaoJdbcImpl.java
@@ -113,7 +113,6 @@ public class UserDaoJdbcImpl implements UserDao {
 			return user;
 
 		} catch(DataAccessException e) {
-			e.printStackTrace();
 			return null;
 		}
 	}

--- a/src/main/java/com/example/demo/login/domain/service/FavGiftService.java
+++ b/src/main/java/com/example/demo/login/domain/service/FavGiftService.java
@@ -32,31 +32,31 @@ public class FavGiftService {
 		return dao.searchFavId(userName, giftId);
 	}
 
-	public boolean addGiftToFav(String userName, int giftId) {
+	public boolean create(String userName, int giftId) {
 
-		int favGiftRowNumber = dao.addGiftToFav(userName, giftId);
+		int favGiftRowNumber = dao.create(userName, giftId);
 
-		boolean resultAddGiftToFav = false;
+		boolean result = false;
 
 		if (favGiftRowNumber > 0) {
-			resultAddGiftToFav = true;
+			result = true;
 		}
 
-		return resultAddGiftToFav;
+		return result;
 
 	}
 
-	public boolean deleteGiftFromFav(String userId, int giftId) {
+	public boolean delete(String userId, int giftId) {
 
-		int favGiftRowNumber = dao.deleteGiftFromFav(userId, giftId);
+		int favGiftRowNumber = dao.delete(userId, giftId);
 
-		boolean resultDeleteGiftFromFav = false;
+		boolean result = false;
 
 		if (favGiftRowNumber > 0) {
-			resultDeleteGiftFromFav = true;
+			result = true;
 		}
 
-		return resultDeleteGiftFromFav;
+		return result;
 
 	}
 

--- a/src/main/java/com/example/demo/login/domain/service/FavGiftService.java
+++ b/src/main/java/com/example/demo/login/domain/service/FavGiftService.java
@@ -17,9 +17,9 @@ public class FavGiftService {
 	@Autowired
 	FavGiftDao dao;
 
-	public List<FavGift> selectMany(String userName) {
+	public List<FavGift> selectAll(String userName) {
 
-		return dao.selectMany(userName);
+		return dao.selectAll(userName);
 	}
 
 	public int count(String userName) {
@@ -34,11 +34,11 @@ public class FavGiftService {
 
 	public boolean create(String userName, int giftId) {
 
-		int favGiftRowNumber = dao.create(userName, giftId);
+		int suceededRowNumber = dao.create(userName, giftId);
 
 		boolean result = false;
 
-		if (favGiftRowNumber > 0) {
+		if (suceededRowNumber > 0) {
 			result = true;
 		}
 
@@ -48,11 +48,11 @@ public class FavGiftService {
 
 	public boolean delete(String userId, int giftId) {
 
-		int favGiftRowNumber = dao.delete(userId, giftId);
+		int suceededRowNumber = dao.delete(userId, giftId);
 
 		boolean result = false;
 
-		if (favGiftRowNumber > 0) {
+		if (suceededRowNumber > 0) {
 			result = true;
 		}
 

--- a/src/main/java/com/example/demo/login/domain/service/FavGiftService.java
+++ b/src/main/java/com/example/demo/login/domain/service/FavGiftService.java
@@ -32,31 +32,31 @@ public class FavGiftService {
 		return dao.searchFavId(userName, giftId);
 	}
 
-	public boolean insert(String userName, int giftId) {
+	public boolean addGiftToFav(String userName, int giftId) {
 
-		int rowNumber = dao.insert(userName, giftId);
+		int favGiftRowNumber = dao.addGiftToFav(userName, giftId);
 
-		boolean result = false;
+		boolean resultAddGiftToFav = false;
 
-		if (rowNumber > 0) {
-			result = true;
+		if (favGiftRowNumber > 0) {
+			resultAddGiftToFav = true;
 		}
 
-		return result;
+		return resultAddGiftToFav;
 
 	}
 
-	public boolean delete(String userId, int giftId) {
+	public boolean deleteGiftFromFav(String userId, int giftId) {
 
-		int rowNumber = dao.delete(userId, giftId);
+		int favGiftRowNumber = dao.deleteGiftFromFav(userId, giftId);
 
-		boolean result = false;
+		boolean resultDeleteGiftFromFav = false;
 
-		if (rowNumber > 0) {
-			result = true;
+		if (favGiftRowNumber > 0) {
+			resultDeleteGiftFromFav = true;
 		}
 
-		return result;
+		return resultDeleteGiftFromFav;
 
 	}
 

--- a/src/main/resources/static/css/favorite.css
+++ b/src/main/resources/static/css/favorite.css
@@ -6,7 +6,7 @@
  	float:left;
  }
 
-p.resultCount {
+p.resultNumber {
 	position: relative;
  	float:left;
 	margin-top: 0px;

--- a/src/main/resources/templates/giftDetail/giftDetail.html
+++ b/src/main/resources/templates/giftDetail/giftDetail.html
@@ -20,13 +20,13 @@
 		<div class="gift-left col-sm-5 ">
 			<img  class="gift-image" th:src="@{'/image/'+${giftDetail.image}}" alt="gift-image">
 			<div   sec:authorize="isAuthenticated()">
-				<form id="createFavGift" th:action="@{/createFavGift}" method="post">
+				<form id="favGift" th:action="@{/favGift}" method="post">
 					<input th:value="${giftDetail.giftId}" name="giftId" type="hidden" />
-					<button th:if="${favIdResultModel == 0}" class="update-btn btn-warning col-sm-4 offset-sm-9" style="color:white" type="submit" ><i class="fas fa-heart" style="color:white"></i> お気に入り</button>
+					<button th:if="${favId == 0}" class="update-btn btn-warning col-sm-4 offset-sm-9" style="color:white" type="submit" ><i class="fas fa-heart" style="color:white"></i> お気に入り</button>
             	</form>
-            	<form id="deleteGiftFromFav" th:action="@{/deleteGiftFromFav}" method="post">
+            	<form id="notFavGift" th:action="@{/notFavGift}" method="post">
 					<input th:value="${giftDetail.giftId}" name="giftId" type="hidden" />
-					<button th:unless="${favIdResultModel == 0}" class="update-btn btn-danger col-sm-5 offset-sm-8" style="color:white" type="submit" ><i class="fas fa-ban" style="color:white"></i> お気に入り解除</button>
+					<button th:unless="${favId == 0}" class="update-btn btn-danger col-sm-5 offset-sm-8" style="color:white" type="submit" ><i class="fas fa-ban" style="color:white"></i> お気に入り解除</button>
             	</form>
 
 			</div>

--- a/src/main/resources/templates/giftDetail/giftDetail.html
+++ b/src/main/resources/templates/giftDetail/giftDetail.html
@@ -20,7 +20,7 @@
 		<div class="gift-left col-sm-5 ">
 			<img  class="gift-image" th:src="@{'/image/'+${giftDetail.image}}" alt="gift-image">
 			<div   sec:authorize="isAuthenticated()">
-				<form id="addGiftToFav" th:action="@{/addGiftToFav}" method="post">
+				<form id="createFavGift" th:action="@{/createFavGift}" method="post">
 					<input th:value="${giftDetail.giftId}" name="giftId" type="hidden" />
 					<button th:if="${favIdResultModel == 0}" class="update-btn btn-warning col-sm-4 offset-sm-9" style="color:white" type="submit" ><i class="fas fa-heart" style="color:white"></i> お気に入り</button>
             	</form>

--- a/src/main/resources/templates/giftDetail/giftDetail.html
+++ b/src/main/resources/templates/giftDetail/giftDetail.html
@@ -20,11 +20,11 @@
 		<div class="gift-left col-sm-5 ">
 			<img  class="gift-image" th:src="@{'/image/'+${giftDetail.image}}" alt="gift-image">
 			<div   sec:authorize="isAuthenticated()">
-				<form id="addGift" th:action="@{/addGift}" method="post">
+				<form id="addGiftToFav" th:action="@{/addGiftToFav}" method="post">
 					<input th:value="${giftDetail.giftId}" name="giftId" type="hidden" />
 					<button th:if="${favIdResultModel == 0}" class="update-btn btn-warning col-sm-4 offset-sm-9" style="color:white" type="submit" ><i class="fas fa-heart" style="color:white"></i> お気に入り</button>
             	</form>
-            	<form id="deleteGift" th:action="@{/deleteFavGift}" method="post">
+            	<form id="deleteGiftFromFav" th:action="@{/deleteGiftFromFav}" method="post">
 					<input th:value="${giftDetail.giftId}" name="giftId" type="hidden" />
 					<button th:unless="${favIdResultModel == 0}" class="update-btn btn-danger col-sm-5 offset-sm-8" style="color:white" type="submit" ><i class="fas fa-ban" style="color:white"></i> お気に入り解除</button>
             	</form>

--- a/src/main/resources/templates/mypage/favorite/favorite.html
+++ b/src/main/resources/templates/mypage/favorite/favorite.html
@@ -14,9 +14,9 @@
 <body layout:fragment="content">
 	<h1>お気に入り</h1>
 	<div class="favGift col-sm-8 offset-sm-2">
-		<p class="resultNumber" th:text="${number} + '件'"></p><br/>
+		<p class="resultNumber" th:text="${count} + '件'"></p><br/>
 		<div class="favGift col-sm-12">
-			<div class="gift" th:each="gift : ${allfavGifts}">
+			<div class="gift" th:each="gift : ${allFavGifts}">
 				<div class="gift2">
 		    		<a th:href="@{'/giftDetail/'+${gift.giftId}}"><img class="gift-picture" th:src="@{'/image/'+${gift.image}}" alt="gift-image"></a>
 					<p class="gift-name" th:text="${gift.giftName}"></p>

--- a/src/main/resources/templates/mypage/favorite/favorite.html
+++ b/src/main/resources/templates/mypage/favorite/favorite.html
@@ -14,9 +14,9 @@
 <body layout:fragment="content">
 	<h1>お気に入り</h1>
 	<div class="favGift col-sm-8 offset-sm-2">
-		<p class="resultCount" th:text="${favGiftListCount} + '件'"></p><br/>
+		<p class="resultNumber" th:text="${number} + '件'"></p><br/>
 		<div class="favGift col-sm-12">
-			<div class="gift" th:each="gift : ${favGiftList}">
+			<div class="gift" th:each="gift : ${allfavGifts}">
 				<div class="gift2">
 		    		<a th:href="@{'/giftDetail/'+${gift.giftId}}"><img class="gift-picture" th:src="@{'/image/'+${gift.image}}" alt="gift-image"></a>
 					<p class="gift-name" th:text="${gift.giftName}"></p>


### PR DESCRIPTION
@kamina-zzz 
「FavGiftDaoJdbcFavGiftDaoJdbcImpl」でエラーキャッチする仕様で進めたいです。

というのもここでは、お土産登録/削除ボタンの出し分けをしており、
ログイン後詳細画面では下記のような条件分岐でお気に入りボタンを出し分けをしています。

①テーブル「favGift」のカラム「userId」「giftId」が指定の組み合わせでレコードが登録されている
→favIdがselect→詳細画面で「お気に入り解除」ボタンを表示

①テーブル「favGift」のカラム「userId」「giftId」が指定の組み合わせでレコードが登録されていない→DataAccessexception発生→favIdに0を代入→詳細画面で「お気に入り」ボタンを表示


つまりこのメソッドに置いて「DataAccessexception」は想定内のエラーで、メソッドとして正常な挙動です。
エラーとして取り扱うものではなくむしろ利用しています。

仮に、メソッドの呼び出しクラスでエラーキャッチすると、お気に入り未登録のお土産の詳細画面を開くたびに、
エラーログがコンソールに表示されてしまいます(呼び出し先のFavGiftDaoJdbcFavGiftDaoJdbcImplクラスでエラーが発生するため)
コンソールにエラーメッセージ/エラーログを出さないためには、「FavGiftDaoJdbcFavGiftDaoJdbcImpl」でエラーキャッチする必要があります。


	@Override
	public int searchFavId(String userName, int giftId) {


		try {
			Map<String, Object> userId = jdbc.queryForMap("SELECT userId FROM userData WHERE userName = ?", userName);


			Map<String, Object> favId = jdbc.queryForMap("SELECT favId FROM favGift WHERE userId = ? AND giftId = ? AND favGift.unavailableFlag IS NULL", userId.get("userId"), giftId);


			int castedFavId =  (int) favId.get("favId");


			return castedFavId;


		} catch(DataAccessException e) {
			int favId = 0;


			return favId;
		}

